### PR TITLE
Dub package failed to build with warnings to use D style instead of C…

### DIFF
--- a/src/box.d
+++ b/src/box.d
@@ -3,24 +3,12 @@ module box;
 import random;
 
 extern (C) {
-  size_t crypto_box_seedbytes();
-  size_t crypto_box_publickeybytes();
-  size_t crypto_box_secretkeybytes();
-  size_t crypto_box_beforenmbytes();
-  size_t crypto_box_noncebytes();
-  size_t crypto_box_zerobytes();
-  size_t crypto_box_boxzerobytes();
-  size_t crypto_box_macbytes();
-
-  char *crypto_box_primitive();
-
-  int crypto_box_seed_keypair(ref ubyte[32] pk, ref ubyte[32] sk);
   int crypto_box_keypair(ref ubyte[32] pk, ref ubyte[32] sk);
   int crypto_box_easy(ubyte *c, ubyte *m, ulong mlen, ref ubyte[24] n, ref ubyte[32] pk, ref ubyte[32] sk);
   int crypto_box_open_easy(ubyte *m, ubyte *c, ulong clen, ref ubyte[24] n, ref ubyte[32] pk, ref ubyte[32] sk);
 }
 
-struct EncryptedBoxMessage {
+struct EncryptedMessage {
   ubyte[] message;
   ubyte[24] nonce;
 }
@@ -30,7 +18,7 @@ class BoxKeyPair {
   ubyte[32] secret_key;
 
   this() {
-    assert(crypto_box_keypair(this.public_key, this.secret_key) == 0);
+    crypto_box_keypair(this.public_key, this.secret_key);
   }
 
   this(ubyte[32] pkey, ubyte[32] skey) {
@@ -38,26 +26,26 @@ class BoxKeyPair {
     this.secret_key = skey;
   }
 
-  EncryptedBoxMessage encrypt(string data, BoxKeyPair other) {
+  EncryptedMessage encrypt(string data, BoxKeyPair other) {
     return this.encrypt(cast(ubyte[])data, other);
   }
 
-  EncryptedBoxMessage encrypt(ubyte[] data, BoxKeyPair other) {
+  EncryptedMessage encrypt(ubyte[] data, BoxKeyPair other) {
     ubyte[24] nonce;
     randombytes_buf(&nonce[0], 24);
     return this.encrypt(data, nonce, other);
   }
 
-  EncryptedBoxMessage encrypt(ubyte[] data, ubyte[24] nonce, BoxKeyPair other) {
-    ubyte[] output = new ubyte[data.length + crypto_box_macbytes()];
+  EncryptedMessage encrypt(ubyte[] data, ubyte[24] nonce, BoxKeyPair other) {
+    ubyte[] output = new ubyte[data.length + 16];
 
-    assert(crypto_box_easy(&output[0], &data[0], data.length, nonce, other.public_key, this.secret_key) == 0);
-    return EncryptedBoxMessage(output, nonce);
+    crypto_box_easy(&output[0], &data[0], data.length, nonce, other.public_key, this.secret_key);
+    return EncryptedMessage(output, nonce);
   }
 
-  ubyte[] decrypt(EncryptedBoxMessage msg, BoxKeyPair other) {
-    ubyte[] output = new ubyte[msg.message.length - crypto_box_macbytes()];
-    assert(crypto_box_open_easy(&output[0], &msg.message[0], msg.message.length, msg.nonce, other.public_key, this.secret_key) == 0);
+  ubyte[] decrypt(EncryptedMessage msg, BoxKeyPair other) {
+    ubyte[] output = new ubyte[msg.message.length - 16];
+    crypto_box_open_easy(&output[0], &msg.message[0], msg.message.length, msg.nonce, other.public_key, this.secret_key);
     return output;
   }
 
@@ -68,13 +56,13 @@ unittest {
   auto alex = new BoxKeyPair;
 
   // Test that encryption works
-  EncryptedBoxMessage emsg = jim.encrypt("hey alex, your password is 1", alex);
+  EncryptedMessage emsg = jim.encrypt("hey alex, your password is 1", alex);
   assert(alex.decrypt(emsg, jim) == "hey alex, your password is 1");
 
   // Test that encryption with custom nonce works
-  ubyte[24] nonce = cast(ubyte[24])"nonce";
-  ubyte[] msg = cast(ubyte[])"test";
-  EncryptedBoxMessage noncemsg = jim.encrypt(msg, nonce, alex);
+  ubyte nonce[24] = cast(ubyte[24])"nonce";
+  ubyte msg[] = cast(ubyte[])"test";
+  EncryptedMessage noncemsg = jim.encrypt(msg, nonce, alex);
   assert(alex.decrypt(noncemsg, jim) == msg);
   assert(noncemsg.nonce == nonce);
 }


### PR DESCRIPTION
… style e.g.
   ubyte vars[32] ==> ubyte[32] vars

using DUB version 0.9.24+155-gc593582, built on Feb 16 2016
just built from github source